### PR TITLE
Truthful MacPaw disclaimer + keg-derived update target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [semver](https://semver.org).
 
+## [Unreleased]
+
+### Fixed
+
+- `cleanmymac update` on Homebrew installs now derives its own formula name
+  (tap + token) from the install receipt and Cellar path instead of
+  hardcoding the personal tap — works unchanged for any tap or a future
+  homebrew-core name.
+- README: removed an incorrect claim that this project predates MacPaw's
+  CleanMyMac (it does not — this repo is from 2018, MacPaw's product from
+  2008/2009). The disclaimer now states the facts.
+
 ## [2.0.1] - 2026-08-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ npm/pnpm/yarn/bun, Python (uv/pipx/conda), Rust, Go, Composer, mise, the Mac
 App Store, your AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Copilot
 via gh), and opt-in cache pruners for Docker and Xcode.
 
-> Not affiliated with MacPaw's CleanMyMac products. This is an independent,
-> open-source shell tool that predates any resemblance.
+> Not affiliated with MacPaw or its CleanMyMac products. This is an
+> independent, unrelated open-source shell tool; the similar name is a
+> historical accident of this repo's 2018 naming, nothing more.
 
 ```
 $ cleanmymac

--- a/bin/cleanmymac
+++ b/bin/cleanmymac
@@ -246,9 +246,22 @@ cmd_update() {
       ;;
     brew)
       note "This install is managed by Homebrew — updating via brew…"
-      # Fully qualified: a bare "cleanmymac" is ambiguous with an unrelated
-      # cask of the same name in homebrew/cask.
-      brew upgrade aviral2552/tap/cleanmymac
+      # Derive our own fully-qualified formula name from the keg instead of
+      # hardcoding it: the token comes from the Cellar path
+      # (…/Cellar/<token>/<version>/libexec) and the tap from the install
+      # receipt. Fully qualified because a bare "cleanmymac" is ambiguous
+      # with an unrelated cask of the same name in homebrew/cask.
+      local keg token tap=""
+      keg="${CMM_ROOT%/libexec}"
+      token="$(basename "${keg%/*}")"
+      if [ -f "$keg/INSTALL_RECEIPT.json" ]; then
+        tap="$(sed -n 's/.*"tap":[[:space:]]*"\([^"]*\)".*/\1/p' "$keg/INSTALL_RECEIPT.json" | head -n 1)"
+      fi
+      if [ -n "$tap" ]; then
+        brew upgrade "$tap/$token"
+      else
+        brew upgrade "$token"
+      fi
       ;;
     *)
       err "cannot self-update: this copy has no .git directory and is not Homebrew-managed"

--- a/tests/runner.bats
+++ b/tests/runner.bats
@@ -203,6 +203,53 @@ teardown() { teardown_sandbox; }
   [ "$status" -eq 2 ]
 }
 
+# Build a realistic brew keg (Cellar/<token>/<ver>/libexec) around the real
+# bin+lib, with a stub brew answering --prefix, and return the launcher path.
+make_fake_keg() {
+  local token="$1" tap="$2" pfx="$SANDBOX/brewpfx"
+  local keg="$pfx/Cellar/$token/9.9.9"
+  mkdir -p "$keg/libexec" "$pfx/bin"
+  cp -R "$REPO_ROOT/bin" "$REPO_ROOT/lib" "$REPO_ROOT/VERSION" "$keg/libexec/"
+  mkdir -p "$keg/libexec/cleaners"
+  [ -n "$tap" ] && printf '{"source":{"spec":"stable","tap":"%s"}}' "$tap" >"$keg/INSTALL_RECEIPT.json"
+  ln -s "$keg/libexec/bin/cleanmymac" "$pfx/bin/$token"
+  cat >"$STUB_BIN/brew" <<EOF
+#!/bin/sh
+[ "\$1" = "--prefix" ] && { echo "$pfx"; exit 0; }
+printf '%s %s\n' brew "\$*" >>"\$CALL_LOG"
+exit 0
+EOF
+  chmod 755 "$STUB_BIN/brew"
+  printf '%s\n' "$pfx/bin/$token"
+}
+
+@test "update on a brew install upgrades its own fully-qualified formula (tap derived from receipt)" {
+  local launcher
+  launcher="$(make_fake_keg mytool someuser/tap)"
+  unset CMM_BREW_PREFIX
+  run "$launcher" update
+  [ "$status" -eq 0 ]
+  grep -q '^brew upgrade someuser/tap/mytool$' "$CALL_LOG"
+}
+
+@test "update on a core-installed keg uses the core-qualified name" {
+  local launcher
+  launcher="$(make_fake_keg coretool homebrew/core)"
+  unset CMM_BREW_PREFIX
+  run "$launcher" update
+  [ "$status" -eq 0 ]
+  grep -q '^brew upgrade homebrew/core/coretool$' "$CALL_LOG"
+}
+
+@test "update without an install receipt falls back to the bare Cellar token" {
+  local launcher
+  launcher="$(make_fake_keg baretool "")"
+  unset CMM_BREW_PREFIX
+  run "$launcher" update
+  [ "$status" -eq 0 ]
+  grep -q '^brew upgrade baretool$' "$CALL_LOG"
+}
+
 @test "version prints the VERSION file value" {
   run "$CMM" version
   [ "$status" -eq 0 ]


### PR DESCRIPTION
README's precedence claim was wrong (repo 2018, MacPaw 2008/2009) — corrected. `cleanmymac update` now derives its formula name from the install receipt, so it works for any tap or core token unchanged. No release tagged yet; ships with the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)