### PR TITLE
Attribution license term (GPLv3 §7b) + tombstone rename architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Full check
         run: make lint test docs-check
 
+      - name: License files must ship (a release may never carry the README's license claim without the term text)
+        run: git ls-files --error-unmatch LICENSE NOTICE
+
       - name: Build tarball + checksums
         run: |
           VER="$(cat VERSION)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- License: still GPL-3.0-only, now with a GPLv3 §7(b) additional term
+  requiring preservation of attribution to the original project in
+  derivative works (new NOTICE file). Releases ≤ 2.0.1 remain plain
+  GPL-3.0 as published.
+
 ### Fixed
 
 - `cleanmymac update` on Homebrew installs now derives its own formula name

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,29 @@
+NOTICE — cleanmymac
+
+Copyright (C) 2018-2026 Aviral Sharma <https://github.com/aviral2552>
+
+This program is free software, licensed under the GNU General Public
+License, version 3.0 only (see LICENSE).
+
+ADDITIONAL TERM under GNU GPL version 3, section 7(b)
+-----------------------------------------------------
+
+  Preservation of attribution. Any conveyance of this software, or of a
+  work based on it, in source or object form, must preserve the
+  following author attribution in the material itself (for example, by
+  retaining this NOTICE file) or in the Appropriate Legal Notices
+  displayed by works containing it; where the work has documentation or
+  an "About"/help output, reasonably displaying the attribution there
+  also satisfies this term:
+
+      Based on cleanmymac by Aviral Sharma
+      https://github.com/aviral2552/cleanmymac
+
+As provided by GPLv3 section 7, this supplemental term is part of the
+license of this material and may not be removed from copies or
+derivative works. All other rights and obligations are exactly those of
+the GNU GPL v3.0.
+
+Historical note: this term applies to any copy of this material
+conveyed with this NOTICE file; releases up to and including v2.0.1
+were conveyed under GPL-3.0 without it.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cleanmymac
 
 [![CI](https://github.com/aviral2552/cleanmymac/actions/workflows/ci.yml/badge.svg)](https://github.com/aviral2552/cleanmymac/actions/workflows/ci.yml)
-[![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
+[![License: GPL-3.0-only](https://img.shields.io/badge/license-GPL--3.0--only-blue.svg)](#license)
 
 One command that updates and cleans the dev tools on your Mac — Homebrew,
 npm/pnpm/yarn/bun, Python (uv/pipx/conda), Rust, Go, Composer, mise, the Mac
@@ -183,4 +183,6 @@ Keeps your config by default; `--purge` removes that too. Homebrew installs:
 
 ## License
 
-[GPL-3.0](LICENSE)
+[GPL-3.0-only](LICENSE) with one additional term under GPLv3 §7(b): works
+based on this code must preserve attribution to the original project — see
+[NOTICE](NOTICE). Free and open source, copyleft intact; credit required.

--- a/bin/cleanmymac
+++ b/bin/cleanmymac
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # cleanmymac — maintenance for the dev tools on your Mac.
 #
 # Runs every enabled cleaner in cleaners/ (plus your own in

--- a/cleaners/10-homebrew.sh
+++ b/cleaners/10-homebrew.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: brew
 # Homebrew: update, upgrade formulae + casks, drop unneeded deps, health
 # checks, and scrub the download cache.

--- a/cleaners/20-mas.sh
+++ b/cleaners/20-mas.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: mas
 # Mac App Store: upgrade installed apps via the mas CLI.
 set -euo pipefail

--- a/cleaners/30-npm.sh
+++ b/cleaners/30-npm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: npm
 # npm: self-update (standalone installs only), report + update global
 # packages, and garbage-collect the cache.

--- a/cleaners/31-pnpm.sh
+++ b/cleaners/31-pnpm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: pnpm
 # pnpm: drop unreferenced packages from the content-addressable store.
 set -euo pipefail

--- a/cleaners/32-yarn.sh
+++ b/cleaners/32-yarn.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: yarn
 # Yarn: classic (v1) global upgrades + cache clean. Berry (v2+) keeps its
 # caches per-project, so there is nothing global to do.

--- a/cleaners/33-bun.sh
+++ b/cleaners/33-bun.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: bun
 # Bun: clear the global package cache.
 set -euo pipefail

--- a/cleaners/40-python.sh
+++ b/cleaners/40-python.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: uv pipx python3
 # Python tooling: uv self-update (standalone only) + tool upgrades + cache
 # prune, pipx package upgrades, and pip cache purge. The uv upgrade honors

--- a/cleaners/41-conda.sh
+++ b/cleaners/41-conda.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: conda
 # Conda: upgrade all packages and clean caches. -y is mandatory — without it
 # conda prompts and a non-interactive run would hang forever (F4).

--- a/cleaners/45-claude.sh
+++ b/cleaners/45-claude.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: claude
 # Claude Code: self-update standalone installs only (npm/brew installs are
 # updated by those cleaners). Never touches ~/.claude — it holds sessions,

--- a/cleaners/46-codex.sh
+++ b/cleaners/46-codex.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: codex
 # OpenAI Codex CLI: self-update standalone installs only. Never touches
 # ~/.codex — it holds sessions and auth (D3).

--- a/cleaners/47-gemini.sh
+++ b/cleaners/47-gemini.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: gemini
 # Gemini CLI: almost always npm- or brew-managed, in which case those
 # cleaners update it; standalone installs get a pointer, not a guess.

--- a/cleaners/48-gh.sh
+++ b/cleaners/48-gh.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: gh
 # GitHub CLI: upgrade every installed extension (including Copilot). gh
 # itself is usually brew-managed and updated by the homebrew cleaner.

--- a/cleaners/49-cursor.sh
+++ b/cleaners/49-cursor.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: cursor-agent
 # Cursor CLI agent: usually a standalone (curl) install with its own
 # updater. Never touches ~/.cursor — it holds sessions and auth (D3).

--- a/cleaners/50-rustup.sh
+++ b/cleaners/50-rustup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: rustup
 # Rust: update toolchains (and rustup itself, unless manager-managed —
 # rustup handles that distinction internally).

--- a/cleaners/51-composer.sh
+++ b/cleaners/51-composer.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: composer
 # Composer: upgrade global packages and clear the download cache.
 set -euo pipefail

--- a/cleaners/52-go.sh
+++ b/cleaners/52-go.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: go
 # Go: clear the build cache. The module cache is left alone on purpose —
 # purging it forces a re-download of every dependency of every project.

--- a/cleaners/55-mise.sh
+++ b/cleaners/55-mise.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: mise
 # mise: self-update standalone installs (-y — it prompts otherwise), report
 # outdated tool versions, and clear its cache. `mise upgrade` is deliberately

--- a/cleaners/60-docker.sh
+++ b/cleaners/60-docker.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: docker
 # Docker (disabled by default — enable with `cleanmymac enable docker`):
 # prune the build cache and dangling images ONLY. Containers, volumes, and

--- a/cleaners/70-xcode.sh
+++ b/cleaners/70-xcode.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # gate: xcodebuild
 # Xcode (disabled by default — enable with `cleanmymac enable xcode`):
 # delete simulators for runtimes that are no longer installed, and purge

--- a/docs/rename-plan-scrubmac.md
+++ b/docs/rename-plan-scrubmac.md
@@ -26,6 +26,8 @@ verified against Homebrew 6 source, and 15 more — inline throughout.*
 | Old lock name | 3.x also holds the legacy `cleanmymac.$uid.lock` for the shim's lifetime | a 2.x cron copy and 3.x must still mutually exclude (remove in v4) |
 | Tap migration | **`formula_renames.json` + DELETE old formula** (primary); deprecate!-only is the mutually-exclusive fallback | verified in Homebrew 6 `formulary.rb`: the renames entry shadows the old formula file unconditionally — keeping both makes the deprecation dead code and violates brew's rename docs |
 | History/identity | README keeps: "formerly `cleanmymac` (2018–2026), renamed to end confusion with MacPaw's unrelated products" | honest provenance; MacPaw's *CleanMyMac* product name legitimately remains in docs |
+| Old repo's fate | **kept as a public archived tombstone** (owner decision 2026-08): pinned pre-P1 history + sunset commit + duplicate v2.0.0/v2.0.1 releases, Actions disabled, then archived — **permanent once the NOTICE attribution URL ships** | visible "renamed and moved" note beats a silent redirect; consequences engineered in P2 |
+| License | GPL-3.0-only **+ GPLv3 §7(b) attribution term** (NOTICE file, added pre-rename) | stays free & copyleft; derivatives must credit the original project. Sole copyright holder verified (all git identities = one person). NOTICE's canonical URL flips to scrubmac in P5. SPDX has no id for §7-augmented GPL — formula stanza stays `GPL-3.0-only`; disclose the term if homebrew-core review asks (§7 terms are GPL-sanctioned and DFSG-compatible) |
 | homebrew-core | deferred until ≥225 stars / ≥90 forks / ≥90 watchers | §7; token becomes `scrubmac` |
 
 ## 1. Inventory (ground truth 2026-08-09: 33 files, 306 occurrences)
@@ -185,11 +187,63 @@ uninstall, legacy lock mutual exclusion, `cmm_config_dir` old+new literal
 pins. DoD: `make lint test docs-check` green (~130 tests), two-sided §1 gate
 clean, §6 matrix green. PR → CI → merge. *Rollback: don't merge.*
 
-**P2 — GitHub rename** (minutes). `gh repo delete aviral2552/scrubmac`
-(placeholder) → `gh api -X PATCH repos/aviral2552/cleanmymac -f name=scrubmac`
-→ update local remotes + tap README → verify old URL still answers via
-redirect. **Hard rule forever: never create a new repo named `cleanmymac`
-— it would sever the redirect.** *Rollback: rename back.*
+**P2 — GitHub rename + tombstone** (owner decision 2026-08: keep a visible
+`cleanmymac` repo saying "renamed and moved" rather than relying on the
+silent redirect; this deliberately trades the automatic redirect for a
+signpost). Order is load-bearing; steps 0–2 shrink the asset-404 window to
+~a minute:
+0. **Pre-flight/pre-stage** (before anything irreversible): `gh auth refresh
+   -h github.com -s delete_repo` (the placeholder delete needs the scope;
+   drop it afterwards). Author the sunset commit on a local branch, **based
+   on the parent of the P1 merge commit** (the sunset diff only makes sense
+   on the 2.x tree; pinning the base also keeps every pre-P1 clone
+   fast-forwardable). Download BOTH releases' assets (v2.0.0, v2.0.1) and
+   verify sha256 against the tap's pinned stanzas. Run P2 immediately after
+   P1 merges — any git user who pulls in the gap lands on v3 master, which
+   is NOT in tombstone history; their later `cleanmymac update` hits the
+   ff-only refusal ("diverged") with no hint. Keep the gap near zero and
+   note the cohort in release notes.
+1. `gh repo delete aviral2552/scrubmac` (placeholder) →
+   `gh api -X PATCH repos/aviral2552/cleanmymac -f name=scrubmac` — stars,
+   forks, watchers, issues, releases, history all move with the rename.
+   Update local remotes + tap README; verify the new URL.
+2. Create the **new** `aviral2552/cleanmymac` (public) and IMMEDIATELY
+   **disable Actions** — `gh api -X PUT
+   repos/aviral2552/cleanmymac/actions/permissions -F enabled=false` —
+   BEFORE any push. The workflow files exist at the tag refs and tag-push
+   runs execute the workflow as of the tag's commit: with Actions on, every
+   pushed tag re-runs release.yml (guard passes at each tag), racing the
+   manual asset re-upload with a freshly built tarball whose bytes are not
+   guaranteed to match the tap's pinned sha — a self-inflicted
+   "tampering" signature; ci.yml would likewise leave a permanent red X on
+   the sunset commit. Then push the pinned base + sunset commit as master,
+   and the tags. Sunset commit contents: README tombstone ("**Renamed and
+   moved → github.com/aviral2552/scrubmac**", migration commands,
+   attribution note per NOTICE); a `warn` at `bin/cleanmymac` startup;
+   `cmd_update` rewritten to print the moved-notice instead of pulling.
+   Exit check: `gh run list -R aviral2552/cleanmymac` shows ZERO runs.
+   Set description ("Renamed and moved to aviral2552/scrubmac") + homepage
+   (the scrubmac URL) now — archived repos are read-only.
+   *Corrected redirect model (verified):* GitHub redirects follow the
+   REPOSITORY, not the name-chain — old-username
+   `thelamehacker/cleanmymac` remotes resolve to the renamed repo id and
+   therefore track **scrubmac**, not the tombstone; that cohort's migration
+   signal is the v3 shim. Only `aviral2552/cleanmymac` URLs land on the
+   tombstone. Execution check: `git ls-remote` both URLs and compare HEADs.
+3. Recreate **both releases** (v2.0.0 AND v2.0.1) on the tombstone:
+   `gh release create vX --verify-tag` with the pre-staged byte-identical
+   assets and the original release bodies (`gh release view vX --json body
+   -R aviral2552/scrubmac`). Old asset URLs
+   (`…/cleanmymac/releases/download/…`, referenced by pre-migration tap
+   formulae) must keep resolving. Exit check: `curl -L` each
+   `/releases/download/` URL and re-verify sha256 against the tap stanzas.
+4. **Archive** the tombstone (last step — read-only afterwards). GitHub's
+   "Archived" banner + the README is the "renamed and moved" note.
+*Rollback: before step 2, plain rename-back. After step 2: delete the
+tombstone and rename back — but ONLY until the NOTICE attribution URL has
+shipped in a release; from then on the tombstone is **permanent**
+(deleting it would break downstream attribution compliance).* Hard rule:
+the tombstone is the ONLY thing that may ever occupy the old name.
 
 **P3 — Release 3.0.0.** Tag → workflow publishes `scrubmac-3.0.0.tar.gz` +
 `SHA256SUMS` → verify independently. Release notes = §3.5 table + the honest
@@ -209,6 +263,14 @@ commits.*
 
 **P5 — Comms & bookkeeping.** Repo description/topics; README pins new URLs;
 `docs/renaming.md` → EXECUTED; memory notes; release-notes announcement.
+**Cross-repo links**: update `aviral2552/macOS-toolkit` README — its
+"Clean My macOS" entry links `https://github.com/thelamehacker/cleanmymac`
+(old username; works today via user-level redirect) → point it at
+`https://github.com/aviral2552/scrubmac` with a "(formerly cleanmymac)"
+note. Sweep any other own-account references (`gh search code --owner`).
+**Licensing follow-through**: update the NOTICE attribution block's canonical
+name/URL to `scrubmac … github.com/aviral2552/scrubmac` (keeping "formerly
+cleanmymac"), and mirror the attribution line in the tombstone README.
 Within days: reserve `scrubmac` on npm/PyPI only as functional pointer
 packages (both registries prohibit pure squatting).
 
@@ -262,7 +324,11 @@ install.sh, uninstall.sh, CHANGELOG.md, or docs/ other than cleaners.md.
 |---|---|
 | formula_renames.json misbehaves in third-party taps | P4(a) live verify before announcing; documented fallback **including the 2.0.2 announcement release** (deprecation alone is invisible to existing users — verified in brew's upgrade.rb) |
 | someone claims `scrubmac` elsewhere pre-execution | GitHub reserved; npm/PyPI functional pointers in P5; don't sit on the plan for months |
-| GitHub redirect severed later | never re-create a `cleanmymac` repo |
+| redirect severance (now INTENTIONAL — tombstone) | old asset URLs kept alive by duplicate v2.0.0 + v2.0.1 releases on the tombstone (P2.3, pre-staged to shrink the 404 window to ~a minute); frozen git clones get a loud sunset nag + rewritten `update` notice (P2.2); nothing else may ever occupy the old name |
+| tombstone pushed/archived in wrong order | archive is the LAST P2 step (read-only afterwards); description/homepage set before archiving |
+| Actions auto-fires on tombstone tag pushes | **disable Actions before the first push** (P2.2) — else release.yml re-runs at each tag and can sha-poison the load-bearing asset URLs; exit check: zero runs |
+| `thelamehacker` username owned by a third party (uid 152917500) | un-mitigatable exposure for old-username remotes/links: that account could create `thelamehacker/cleanmymac` at any time and capture them. Own links fixed (macOS-toolkit README, 2026-08-09); release notes must tell old-username remotes to re-point; the redirect they ride today goes to scrubmac (repo-id), NOT the tombstone |
+| users who pulled in the P1→P2 gap | ff-refusal dead end on the tombstone; P2.0 pins the sunset base and mandates running P2 immediately after P1; cohort called out in release notes |
 | sed over/under-reach | explicit include-list from tracked files only (§5); two-sided gate (§1); hunk review |
 | users with both config dirs / symlinked config | §3.1 branches: prefer new, warn, never delete, never silently lose a dotfiles symlink |
 | old name captured by MacPaw's CLI on user machines | by design (name released); §3.2(5b) check + caveat + release notes say it out loud |

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # install.sh — install cleanmymac into ~/.cleanmymac and link it onto PATH.
 #
 # Safety properties (see docs/security.md):

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # lib/common.sh — shared helpers for cleanmymac and its cleaners.
 #
 # Sourced, never executed. Compatible with the bash 3.2 that ships with macOS:

--- a/lib/wizard.sh
+++ b/lib/wizard.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # lib/wizard.sh — the powerlevel10k-style setup wizard.
 #
 # Sourced by bin/cleanmymac (never executed directly), so discover(),

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # docs-check.sh — fail when cleaners/ and docs/cleaners.md drift apart (D9).
 # Every cleaners/NN-name.sh must have a "### name" heading in the reference,
 # and every "### name" heading must correspond to a shipped cleaner.

--- a/tests/cleaners.bats
+++ b/tests/cleaners.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # Per-cleaner tests against PATH stubs: exact argv sequences, skip-when-absent,
 # and the regression pins from the plan (F4–F8, S4, D3, D4).
 

--- a/tests/helpers/setup.bash
+++ b/tests/helpers/setup.bash
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # shellcheck disable=SC2016  # single-quoted $-expressions here are deliberate: they expand later, in generated scripts
 # tests/helpers/setup.bash — sandbox + stub factory shared by every suite.
 #

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # install.sh: sandboxed installs — layout, symlink, idempotence, legacy
 # purge via --delete, .git preservation, seeded defaults, no sudo ever.
 

--- a/tests/lib.bats
+++ b/tests/lib.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # lib/common.sh unit tests: run/try/dry-run, skip contract, config parsing,
 # dates, install-kind classification, safety guards.
 

--- a/tests/runner.bats
+++ b/tests/runner.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # Dispatcher behavior: continue-on-failure, exit codes, selection, disabling,
 # shadowing, dry-run, quiet buffering, locking, summary.
 

--- a/tests/security.bats
+++ b/tests/security.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # Security guarantees (S1–S7): execution-safety guards at the dispatcher
 # level, config-injection inertness end to end, ff-only self-update, and
 # code-level pins (no eval, root guards present).

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # uninstall.sh: sandboxed removal — symlinks (incl. dangling legacy ones),
 # app dir, config keep-vs-purge, graceful when nothing is installed.
 

--- a/tests/wizard.bats
+++ b/tests/wizard.bats
@@ -1,4 +1,7 @@
 #!/usr/bin/env bats
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # Wizard: stdin-driven full passes, toggling, restart/quit, first-run flows.
 # CMM_WIZARD_ASSUME_TTY=1 lets tests drive the interactive path via stdin.
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Part of cleanmymac — Copyright (C) 2018-2026 Aviral Sharma.
+# Licensed GPL-3.0-only with an additional attribution term under
+# GPLv3 section 7(b) — see the LICENSE and NOTICE files at the project root.
 # uninstall.sh — remove cleanmymac. Never sudo.
 #
 #   ./uninstall.sh            removes the app dir + PATH/man symlinks;


### PR DESCRIPTION
License: stays GPL-3.0-only, adds a §7(b) attribution term (NOTICE + per-file pointers + release-ship guard). Plan: old repo will be kept as an archived tombstone; P2 rebuilt around review findings (Actions kill-switch, pinned sunset base, dual release duplication, corrected redirect model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)